### PR TITLE
More downstream contributions back

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -154,8 +154,10 @@ Downstream contributions back (number of commits, ):
     FSL : 108
     PyMVPA : 87
     Nipype : 65
+    MichielCottaar/cifti : 60
     dcmstack : 22
     MNE : 15
+    PySurfer : 13
 
 ### Additional metrics from project code repositories and package managers:
 


### PR DESCRIPTION
For consideration:

* PySurfer : 13 (Alex Gramfort contributed FreeSurfer IO initially used there IIRC)
* MichielCottaar/cifti : 60 (https://github.com/nipy/nibabel/pull/641 deprecated that tool altogether)